### PR TITLE
Fix glyhps

### DIFF
--- a/bitbar.1m.sh
+++ b/bitbar.1m.sh
@@ -3,5 +3,5 @@
 out=$(java -jar /Applications/Prowler.app/Contents/SharedSupport/bin/prowler-0.1.0-SNAPSHOT-standalone.jar)
 export IFS=";"
 for word in $out; do
-    echo $word
+    echo -e $word
 done

--- a/release.sh
+++ b/release.sh
@@ -26,5 +26,3 @@ mkdir -p Prowler.app/Contents/SharedSupport/bin
 cp  ../target/prowler-0.1.0-SNAPSHOT-standalone.jar Prowler.app/Contents/SharedSupport/bin/
 chmod +x Prowler.app/Contents/SharedSupport/bin/prowler-0.1.0-SNAPSHOT-standalone.jar
 popd
-
-cp -R release/Prowler.app .

--- a/src/prowler/core.clj
+++ b/src/prowler/core.clj
@@ -55,11 +55,11 @@
 
 (defn statusToBitBarFormat [ci successStates pendingStates failureStates] (str " | href=" (get-in ci ["target_url"]) (getColorFromStatus (get-in ci ["state"]) successStates pendingStates failureStates)))
 
-(defn prToStatusesToBitBarFormat [pr successStates pendingStates failureStates] (s/join ";" (map (fn [ci] (str "⌊ " (get-in ci ["context"]) (statusToBitBarFormat ci successStates pendingStates failureStates))) (remove #(nil? (get-in % ["context"])) (get-in pr [:ci])))))
+(defn prToStatusesToBitBarFormat [pr successStates pendingStates failureStates] (s/join ";" (map (fn [ci] (str "\\xE2\\x8C\\x8A " (get-in ci ["context"]) (statusToBitBarFormat ci successStates pendingStates failureStates))) (remove #(nil? (get-in % ["context"])) (get-in pr [:ci])))))
 
 (defn prsToBitBarFormat [repo successStates pendingStates failureStates hideMergeConflicts] (s/join ";" (map (fn [pr] (str (get-in pr [:title]) " " (if (or (get-in pr [:mergeable]) hideMergeConflicts) "" "🚫") " | href=" (get-in pr [:url]) ";" (prToStatusesToBitBarFormat pr successStates pendingStates failureStates))) (get-in repo [:prs]))))
 
-(defn toBitBarFormat [manifest successStates pendingStates failureStates hideMergeConflicts] (str "❦;" (s/join ";" (map (fn [repo] (str "---;" (get-in repo [:repo]) " | size=20" ";" (prsToBitBarFormat repo successStates pendingStates failureStates hideMergeConflicts))) manifest))))
+(defn toBitBarFormat [manifest successStates pendingStates failureStates hideMergeConflicts] (str "\\xE2\\x9D\\xA6;" (s/join ";" (map (fn [repo] (str "---;" (get-in repo [:repo]) " | size=20" ";" (prsToBitBarFormat repo successStates pendingStates failureStates hideMergeConflicts))) manifest))))
 
 (defn createManifest [userName repos token services successStates pendingStates failureStates hideMergeConflicts showAllPrs] (println (toBitBarFormat (map (fn [repo]
                                                                                                                                {:repo repo


### PR DESCRIPTION
I used Emojis and Symbols to code in the ⌊ and ❦, leading to problems across OSX versions. Use hexdecimal to represent these chars 
